### PR TITLE
Add deployment scripts and config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: install deploy test nightly
+
+install:
+scripts/install.sh
+
+deploy:
+scripts/deploy.sh
+
+test:
+scripts/test.sh
+
+nightly:
+scripts/nightly.sh

--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# FlipApp LogLine Blueprint
+
+This repository contains the canonical blueprint for the FlipApp logging system. It includes:
+
+- **logline.sql** – SQL schema for LogLine, people, triggers and functions.
+- **supabase/schema.json** – JSON representation of the database schema.
+- **src/semantizar.ts** – Edge function that enriches `logline` records with embeddings and semantic suggestions.
+- **flipapp-codex/** – full-stack reference implementation.
+
+## Overview
+
+LogLine is a structured record capturing any action or observation within the FlipApp ecosystem. It can originate from text, voice, images or any other input. The system normalises the content, extracts entities and stores everything in an auditable timeline. Incomplete entities become **ghost** records that can later be reconciled.
+
+### Example LogLine
+
+```json
+{
+  "who": "user:rafa",
+  "did": "registrou",
+  "this": {
+    "raw": "peguei 2 tina da gaveta",
+    "context": {
+      "item": "tina",
+      "quantidade": "2"
+    }
+  },
+  "status": "raw",
+  "tenant_id": "tenant_voulezvous"
+}
+```
+
+### Lifecycle
+
+| Status       | Transition condition                          | Next state   |
+| ------------ | --------------------------------------------- | ------------ |
+| `raw`        | after 7 days without enrichment               | `archived`   |
+| `enriched`   | embedding and semantic fields completed       | `contextual` |
+| `contextual` | after 180 days of inactivity                  | `archived`   |
+
+## Pipeline from paper, voice or photo
+
+1. **OCR/Transcription** – convert images or audio to text.
+2. **LLM #1** – clean text, segment and detect entities.
+3. **LLM #2** – transform into LogLine structure (`who`, `did`, `this`, `status`).
+4. **LLM #3 (optional)** – semantic validator and reconstructor.
+5. **Storage** – insert into Supabase with status `raw` or `enriched`.
+
+## Deployment
+
+Run the SQL script to set up the database structure. Deploy the edge function in Supabase to automatically semantise logs. Use the JSON schema for migrations or validation tools.
+
+For a full-stack implementation see the **flipapp-codex/** directory.
+
+## Scripts
+
+- `scripts/install.sh` – install Python and Node dependencies
+- `scripts/deploy.sh` – apply database migrations and deploy functions
+- `scripts/test.sh` – run unit tests
+- `scripts/nightly.sh` – tasks for nightly cronjobs
+- `Makefile` – convenience wrapper for these scripts
+
+## Configuration
+
+A basic configuration is provided in `flip.config.json` which references the Mosaic theme and silent layout.
+
+## LogLine
+
+Run `docs/initial_logline.sql` after setup to seed an initial LogLine asserting that "este sistema existe".

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,1 @@
+Additional deployment notes for FlipApp.

--- a/docs/initial_logline.sql
+++ b/docs/initial_logline.sql
@@ -1,0 +1,2 @@
+INSERT INTO logline (tenant_id, who, did, this)
+VALUES ('00000000-0000-0000-0000-000000000000', 'system:codex', 'registrou', '{"raw": "este sistema existe"}');

--- a/flip.config.json
+++ b/flip.config.json
@@ -1,0 +1,7 @@
+{
+  "theme": "mosaic",
+  "layout": "silent",
+  "badge": "institutional",
+  "token": "REPLACE_WITH_TOKEN",
+  "cron": "0 3 * * * /workspace/minisummer/scripts/nightly.sh"
+}

--- a/frontend/layout.html
+++ b/frontend/layout.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>FlipApp</title>
+  <link rel="stylesheet" href="../theme/mosaic.css">
+</head>
+<body>
+<div id="root"></div>
+</body>
+</html>

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+if [ -f logline.sql ]; then
+    echo "[deploy] Applying schema"
+    psql "$SUPABASE_DB" -f logline.sql
+fi
+
+supabase functions deploy semantizar
+
+echo "[deploy] Done"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+if [ -f requirements.txt ]; then
+    echo "[install] Installing Python dependencies"
+    pip install -r requirements.txt
+fi
+
+if [ -f package.json ]; then
+    echo "[install] Installing Node packages"
+    npm install
+fi
+
+echo "[install] Done"

--- a/scripts/nightly.sh
+++ b/scripts/nightly.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+echo "[nightly] Starting"
+# placeholder for nightly tasks
+
+echo "[nightly] Done"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+if command -v pytest >/dev/null 2>&1; then
+    pytest
+else
+    echo "pytest not installed"
+fi

--- a/theme/mosaic.css
+++ b/theme/mosaic.css
@@ -1,0 +1,1 @@
+body { background: #f0f0f0; color: #222; }


### PR DESCRIPTION
## Summary
- provide Makefile and installation/deployment scripts
- add nightly cronjob helper
- add mosaic theme and sample frontend layout
- include configuration file `flip.config.json`
- document how to use these pieces in README
- restore pipeline and overview details in README

## Testing
- `./scripts/test.sh` *(fails: pytest not installed)*
